### PR TITLE
feat: improve efficiency of text modification by automerge text splice

### DIFF
--- a/specification/DOCUMENT.md
+++ b/specification/DOCUMENT.md
@@ -59,7 +59,7 @@ The value of the entry is a Todo (see 2.2).
 
 Each entry in the top-level `todos` map is itself an Automerge Map structure. It cotains:
 
-#### `title` - KindStr
+#### `title` - KindText
 
 The title of the Todo. This describes the goal or definition-of-done of the Todo and is therefore a static string that
 doesn't support splicing and merging. It is strictly LLW.


### PR DESCRIPTION
This PR reduces the size of changes stored for todos by only storing modifications to their description content rather than entire new copies. This is important for longer descriptions where small aspects of the content are being changed and improved over time.

This is expanded to apply to:

- [X] todo title
- [X] todo description