### PR TITLE
feat: added basic author and updated at tracking

### DIFF
--- a/cmd/au/commentcmd/commentcmd.go
+++ b/cmd/au/commentcmd/commentcmd.go
@@ -116,6 +116,10 @@ var createCommand = &cobra.Command{
 			params.Content = []byte(after)
 		}
 
+		if v, ok := cmd.Context().Value(common.CurrentAuthorContextKey).(string); ok && v != "" {
+			params.CreatedBy = v
+		}
+
 		if todo, err := ws.CreateComment(cmd.Context(), cmd.Flags().Arg(0), params); err != nil {
 			return err
 		} else if err := ws.Flush(); err != nil {
@@ -159,6 +163,10 @@ var editCommand = &cobra.Command{
 			return errors.Wrap(err, "failed to get markdown content flag")
 		} else if v != "" {
 			params.Content = []byte(v)
+		}
+
+		if v, ok := cmd.Context().Value(common.CurrentAuthorContextKey).(string); ok && v != "" {
+			params.UpdatedBy = v
 		}
 
 		if v, err := cmd.Flags().GetBool("edit"); err != nil {

--- a/cmd/au/common/ctx.go
+++ b/cmd/au/common/ctx.go
@@ -4,4 +4,5 @@ type contextKey int
 
 const StorageContextKey = contextKey(0)
 const CurrentWorkspaceIdContextKey = contextKey(1)
-const ListenerRefContextKey = contextKey(2)
+const CurrentAuthorContextKey = contextKey(2)
+const ListenerRefContextKey = contextKey(3)

--- a/cmd/au/todocmd/todo.go
+++ b/cmd/au/todocmd/todo.go
@@ -138,6 +138,12 @@ var createCommand = &cobra.Command{
 			}
 		}
 
+		if v, ok := cmd.Context().Value(common.CurrentAuthorContextKey).(string); ok && v != "" {
+			params.CreatedBy = v
+		} else {
+			return errors.New("no author set, please set one for the current workspace")
+		}
+
 		if todo, err := ws.CreateTodo(cmd.Context(), params); err != nil {
 			return err
 		} else if err := ws.Flush(); err != nil {
@@ -221,6 +227,12 @@ var editCommand = &cobra.Command{
 			}
 		}
 
+		if v, ok := cmd.Context().Value(common.CurrentAuthorContextKey).(string); ok && v != "" {
+			params.UpdatedBy = v
+		} else {
+			return errors.New("no author set, please set one for the current workspace")
+		}
+
 		if todo, err := ws.EditTodo(cmd.Context(), cmd.Flags().Arg(0), params); err != nil {
 			return err
 		} else if err := ws.Flush(); err != nil {
@@ -263,13 +275,15 @@ func init() {
 	createCommand.Flags().StringP("title", "t", "", "Set the title of the Todo")
 	createCommand.Flags().String("description", "", "Set the description of the Todo")
 	createCommand.Flags().Bool("edit", false, "Edit the title and description using AU_EDITOR")
-	createCommand.Flags().StringArray("annotation", []string{}, "Set an annotation using key=value synta")
+	createCommand.Flags().StringArray("annotation", []string{}, "Set an annotation using key=value syntax")
+	createCommand.Flags().String("author", "", "Set the author of the Todo as 'Name <email>'")
 
 	editCommand.Flags().StringP("title", "t", "", "Set the title of the Todo")
 	editCommand.Flags().String("description", "", "Set the description of the Todo")
 	editCommand.Flags().String("status", "", "Set the status of the Todo")
 	editCommand.Flags().Bool("edit", false, "Edit the title and description using AU_EDITOR")
 	editCommand.Flags().StringArray("annotation", []string{}, "Set an annotation using key=value or clear an annotation using key=")
+	editCommand.Flags().String("author", "", "Set the author of the Todo update as 'Name <email>'")
 
 	Command.AddCommand(
 		getCommand,

--- a/cmd/au/todocmd/todo_test.go
+++ b/cmd/au/todocmd/todo_test.go
@@ -89,6 +89,8 @@ func TestCli_create_todos(t *testing.T) {
 	assert.NoError(t, yaml.Unmarshal(buff.Bytes(), &outStruct))
 	assert.NotNil(t, outStruct["created_at"].(time.Time))
 	delete(outStruct, "created_at")
+	assert.NotNil(t, outStruct["updated_at"].(time.Time))
+	delete(outStruct, "updated_at")
 	assert.Equal(t, map[string]interface{}{
 		"id":          todoId,
 		"title":       "My todo 2",

--- a/internal/ref.go
+++ b/internal/ref.go
@@ -1,0 +1,5 @@
+package internal
+
+func Ref[k any](input k) *k {
+	return &input
+}

--- a/pkg/au/config.go
+++ b/pkg/au/config.go
@@ -11,6 +11,7 @@ import (
 const (
 	ConfigDirEnvironmentVariable    = "AU_DIRECTORY"
 	WorkspaceUidEnvironmentVariable = "AU_WORKSPACE"
+	AuthorEnvironmentVariable       = "AU_AUTHOR"
 	EditorVariable                  = "AU_EDITOR"
 	GlobalEditorVariable            = "EDITOR"
 	DefaultConfigDir                = "$HOME/.au"
@@ -43,5 +44,13 @@ func ResolveWorkspaceUid(flagValue string) (string, error) {
 		slog.Debug("no workspace uid provided on the cli - falling back to $" + WorkspaceUidEnvironmentVariable)
 		flagValue = os.Getenv(WorkspaceUidEnvironmentVariable)
 	}
-	return "", nil
+	return flagValue, nil
+}
+
+func ResolveAuthor(flagValue string) (string, error) {
+	if flagValue == "" {
+		slog.Debug("no author provided on the cli - falling back to $" + AuthorEnvironmentVariable)
+		flagValue = os.Getenv(AuthorEnvironmentVariable)
+	}
+	return flagValue, nil
 }

--- a/pkg/au/memory_ws_test.go
+++ b/pkg/au/memory_ws_test.go
@@ -149,7 +149,7 @@ func TestEditTodo_check_efficient_description(t *testing.T) {
 		if h := wsp.(DocProvider).GetDoc().Heads(); assert.Len(t, h, 1) {
 			c, _ := wsp.(DocProvider).GetDoc().Change(h[0])
 			assert.Equal(t, "edited todo "+td.Id, c.Message())
-			assert.Len(t, automerge.SaveChanges([]*automerge.Change{c}), 157)
+			assert.Len(t, automerge.SaveChanges([]*automerge.Change{c}), 189)
 		}
 	})
 

--- a/pkg/au/memory_ws_test.go
+++ b/pkg/au/memory_ws_test.go
@@ -38,6 +38,7 @@ func TestCreateTodo_success(t *testing.T) {
 		Annotations: map[string]string{
 			"https://aurelian-one/spec#some-annotation": "something",
 		},
+		CreatedBy: "Example <email@me.com>",
 	})
 	assert.NoError(t, err)
 	_, err = ulid.Parse(td.Id)
@@ -89,6 +90,7 @@ func TestCreateTodo_invalid_annotations(t *testing.T) {
 				Annotations: map[string]string{
 					tc.Key: tc.Value,
 				},
+				CreatedBy: "Example <email@me.com>",
 			})
 			if tc.ExpectedError != "" {
 				assert.EqualError(t, err, tc.ExpectedError)
@@ -106,6 +108,7 @@ func TestEditTodo_success(t *testing.T) {
 	td, err := wsp.CreateTodo(context.Background(), CreateTodoParams{
 		Title:       "Do the thing",
 		Description: "Much longer text about doing the thing",
+		CreatedBy:   "Example <email@me.com>",
 	})
 	assert.NoError(t, err)
 	newTitle, newDescription, newStatus := "Do the other thing", "Short description", "closed"
@@ -113,6 +116,7 @@ func TestEditTodo_success(t *testing.T) {
 		Title:       &newTitle,
 		Description: &newDescription,
 		Status:      &newStatus,
+		UpdatedBy:   "Example <email@me.com>",
 	})
 	assert.NoError(t, err)
 	if h := wsp.(DocProvider).GetDoc().Heads(); assert.Len(t, h, 1) {
@@ -137,19 +141,33 @@ func TestEditTodo_check_efficient_description(t *testing.T) {
 	td, err := wsp.CreateTodo(context.Background(), CreateTodoParams{
 		Title:       "Do the thing",
 		Description: "my original text.",
+		CreatedBy:   "Example <email@me.com>",
 	})
 	assert.NoError(t, err)
 
-	t.Run("changing one byte", func(t *testing.T) {
-		newDescription := "my original text!"
+	t.Run("empty update", func(t *testing.T) {
 		_, err = wsp.EditTodo(context.Background(), td.Id, EditTodoParams{
-			Description: &newDescription,
+			UpdatedBy: "Example <email@me.com>",
 		})
 		assert.NoError(t, err)
 		if h := wsp.(DocProvider).GetDoc().Heads(); assert.Len(t, h, 1) {
 			c, _ := wsp.(DocProvider).GetDoc().Change(h[0])
 			assert.Equal(t, "edited todo "+td.Id, c.Message())
-			assert.Len(t, automerge.SaveChanges([]*automerge.Change{c}), 189)
+			assert.Len(t, automerge.SaveChanges([]*automerge.Change{c}), 190)
+		}
+	})
+
+	t.Run("changing one byte", func(t *testing.T) {
+		newDescription := "my original text!"
+		_, err = wsp.EditTodo(context.Background(), td.Id, EditTodoParams{
+			Description: &newDescription,
+			UpdatedBy:   "Example <email@me.com>",
+		})
+		assert.NoError(t, err)
+		if h := wsp.(DocProvider).GetDoc().Heads(); assert.Len(t, h, 1) {
+			c, _ := wsp.(DocProvider).GetDoc().Change(h[0])
+			assert.Equal(t, "edited todo "+td.Id, c.Message())
+			assert.Len(t, automerge.SaveChanges([]*automerge.Change{c}), 157)
 		}
 	})
 
@@ -157,6 +175,7 @@ func TestEditTodo_check_efficient_description(t *testing.T) {
 		newDescription := "MY ORIGINAL TEXT."
 		_, err = wsp.EditTodo(context.Background(), td.Id, EditTodoParams{
 			Description: &newDescription,
+			UpdatedBy:   "Example <email@me.com>",
 		})
 		assert.NoError(t, err)
 		if h := wsp.(DocProvider).GetDoc().Heads(); assert.Len(t, h, 1) {
@@ -181,6 +200,7 @@ func TestDeleteTodo_success(t *testing.T) {
 	td, err := wsp.CreateTodo(context.Background(), CreateTodoParams{
 		Title:       "Do the thing",
 		Description: "Much longer text about doing the thing",
+		CreatedBy:   "Example <email@me.com>",
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, wsp.DeleteTodo(context.Background(), td.Id))

--- a/pkg/au/storage.go
+++ b/pkg/au/storage.go
@@ -53,14 +53,17 @@ type WorkspaceProvider interface {
 }
 
 type Todo struct {
-	Id           string    `yaml:"id"`
-	CreatedAt    time.Time `yaml:"created_at"`
-	CommentCount int       `yaml:"comment_count"`
+	Id           string     `yaml:"id"`
+	CreatedAt    time.Time  `yaml:"created_at"`
+	CreatedBy    *string    `yaml:"created_by,omitempty"`
+	UpdatedAt    *time.Time `yaml:"updated_at,omitempty"`
+	UpdatedBy    *string    `yaml:"updated_by,omitempty"`
+	CommentCount int        `yaml:"comment_count"`
 
 	Title       string            `yaml:"title"`
-	Description string            `yaml:"description"`
+	Description string            `yaml:"description,omitempty"`
 	Status      string            `yaml:"status"`
-	Annotations map[string]string `yaml:"annotations"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 type CreateTodoParams struct {
@@ -68,6 +71,7 @@ type CreateTodoParams struct {
 	Description string
 	Status      *string
 	Annotations map[string]string
+	CreatedBy   *string
 }
 
 type EditTodoParams struct {
@@ -75,20 +79,26 @@ type EditTodoParams struct {
 	Description *string
 	Status      *string
 	Annotations map[string]string
+	UpdatedBy   *string
 }
 
 type Comment struct {
-	Id        string
-	CreatedAt time.Time
-	MediaType string
-	Content   string
+	Id        string     `yaml:"id"`
+	CreatedAt time.Time  `yaml:"created_at"`
+	CreatedBy *string    `yaml:"created_by,omitempty"`
+	UpdatedAt *time.Time `yaml:"updated_at,omitempty"`
+	UpdatedBy *string    `yaml:"updated_by,omitempty"`
+	MediaType string     `yaml:"media_type"`
+	Content   string     `yaml:"content"`
 }
 
 type CreateCommentParams struct {
 	MediaType string
 	Content   []byte
+	CreatedBy *string
 }
 
 type EditCommentParams struct {
-	Content []byte
+	Content   []byte
+	UpdatedBy *string
 }

--- a/pkg/au/storage.go
+++ b/pkg/au/storage.go
@@ -17,6 +17,9 @@ type StorageProvider interface {
 	GetCurrentWorkspace(ctx context.Context) (string, error)
 	SetCurrentWorkspace(ctx context.Context, id string) error
 
+	GetCurrentAuthor(ctx context.Context) (string, error)
+	SetCurrentAuthor(ctx context.Context, author string) error
+
 	OpenWorkspace(ctx context.Context, id string, writeable bool) (WorkspaceProvider, error)
 }
 
@@ -25,10 +28,10 @@ type DocProvider interface {
 }
 
 type WorkspaceMeta struct {
-	Id        string
-	Alias     string
-	CreatedAt time.Time
-	SizeBytes int64
+	Id        string    `json:"id"`
+	Alias     string    `json:"alias"`
+	CreatedAt time.Time `json:"created_at"`
+	SizeBytes int64     `json:"size_bytes"`
 }
 
 type CreateWorkspaceParams struct {
@@ -55,7 +58,7 @@ type WorkspaceProvider interface {
 type Todo struct {
 	Id           string     `yaml:"id"`
 	CreatedAt    time.Time  `yaml:"created_at"`
-	CreatedBy    *string    `yaml:"created_by,omitempty"`
+	CreatedBy    string     `yaml:"created_by,omitempty"`
 	UpdatedAt    *time.Time `yaml:"updated_at,omitempty"`
 	UpdatedBy    *string    `yaml:"updated_by,omitempty"`
 	CommentCount int        `yaml:"comment_count"`
@@ -71,7 +74,7 @@ type CreateTodoParams struct {
 	Description string
 	Status      *string
 	Annotations map[string]string
-	CreatedBy   *string
+	CreatedBy   string
 }
 
 type EditTodoParams struct {
@@ -79,13 +82,13 @@ type EditTodoParams struct {
 	Description *string
 	Status      *string
 	Annotations map[string]string
-	UpdatedBy   *string
+	UpdatedBy   string
 }
 
 type Comment struct {
 	Id        string     `yaml:"id"`
 	CreatedAt time.Time  `yaml:"created_at"`
-	CreatedBy *string    `yaml:"created_by,omitempty"`
+	CreatedBy string     `yaml:"created_by,omitempty"`
 	UpdatedAt *time.Time `yaml:"updated_at,omitempty"`
 	UpdatedBy *string    `yaml:"updated_by,omitempty"`
 	MediaType string     `yaml:"media_type"`
@@ -95,10 +98,10 @@ type Comment struct {
 type CreateCommentParams struct {
 	MediaType string
 	Content   []byte
-	CreatedBy *string
+	CreatedBy string
 }
 
 type EditCommentParams struct {
 	Content   []byte
-	UpdatedBy *string
+	UpdatedBy string
 }

--- a/pkg/au/validation.go
+++ b/pkg/au/validation.go
@@ -2,6 +2,7 @@ package au
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -99,6 +100,15 @@ func ValidateTodoAnnotationKey(key string) error {
 
 	} else if u.Hostname() == ReservedAnnotationShortHostname {
 		return errors.Errorf("'%s' annotation are reserved", u.Hostname())
+	}
+	return nil
+}
+
+var validAuthorPattern = regexp.MustCompile(`^\S+( \S+) <\S+@\S+>$`)
+
+func ValidatedAuthor(input string) error {
+	if !validAuthorPattern.MatchString(input) {
+		return errors.New("invalid author string, expected 'Name <email>'")
 	}
 	return nil
 }

--- a/pkg/au/validation.go
+++ b/pkg/au/validation.go
@@ -104,7 +104,7 @@ func ValidateTodoAnnotationKey(key string) error {
 	return nil
 }
 
-var validAuthorPattern = regexp.MustCompile(`^\S+( \S+) <\S+@\S+>$`)
+var validAuthorPattern = regexp.MustCompile(`^\S+( \S+)* <\S+@\S+>$`)
 
 func ValidatedAuthor(input string) error {
 	if !validAuthorPattern.MatchString(input) {

--- a/specification/DOCUMENT.md
+++ b/specification/DOCUMENT.md
@@ -78,6 +78,14 @@ The contents should be valid multi-line UTF-8 according to section 3.1 in this d
 
 The time the Todo was created. Usually not editable.
 
+#### `created_by` - KindStr
+
+The author of the Todo. As a "Username <email>" string.
+
+#### `updated_by` - KindStr
+
+The last author of the Todo. As a "Username <email>" string.
+
 #### `status` - KindStr
 
 The required status of the todo. The status is either `open` or `closed`. All todos default to `open`. `closed` should be
@@ -115,6 +123,10 @@ Each comment has the format:
 #### `created_at` - KindTime
 
 The time the Comment was created. Usually not editable.
+
+#### `created_by` - KindStr
+
+The author of the Comment. As a "Username <email>" string.
 
 #### `media_type` - KindStr
 


### PR DESCRIPTION
Ignore the comment structure being in the wrong place, but now tracking authorship and time is working as expected:

```
[27-track-email-address-of-user-creating-comments-and-creatingupdating-todos:￪1￬1 bmeier ~/projects/github.com/aurelian-one/au ⟫ au dev export-workspace
alias: Project A
created_at: "2024-02-09T08:39:48Z"
todos:
  01HP6GDNAEA2A3WJ3X7VHE18C8:
    annotations: {}
    created_at: "2024-02-09T08:40:51Z"
    created_by: Ben Meier <ben@meierhost.com>
    description: '&automerge.Text{"something else"}'
    status: open
    title: '&automerge.Text{"Do the thing"}'
    updated_at: "2024-02-09T08:43:46Z"
    updated_by: Ben Meier <ben@meierhost.com>
  comments:
    01HP6GF6VH1NMHF6WMAP789E67:
      content: TmV3IHN0dWZmCg==
      created_at: "2024-02-09T08:41:42Z"
      created_by: Ben Meier <ben@meierhost.com>
      media_type: text/markdown
      updated_at: "2024-02-09T08:44:11Z"
      updated_by: Ben Meier <ben@meierhost.com>
```

if you haven't set the author for a workspace, you can't edit stuff:

```
[0.02s 27-track-email-address-of-user-creating-comments-and-creatingupdating-todos:d bmeier ~/projects/github.com/aurelian-one/au ⟫ au todo create
Error: no author set, please set one for the current workspace
[1 0.03s 27-track-email-address-of-user-creating-comments-and-creatingupdating-todos:d bmeier ~/projects/github.com/aurelian-one/au ⟫ au workspace set-author 'Ben Meier <ben@meierhost.com>'
[0.06s 27-track-email-address-of-user-creating-comments-and-creatingupdating-todos:d bmeier ~/projects/github.com/aurelian-one/au ⟫ au todo create --title "Do the thing"
id: 01HP6GDNAEA2A3WJ3X7VHE18C8
created_at: 2024-02-09T08:40:51Z
created_by: Ben Meier <ben@meierhost.com>
comment_count: 0
title: Do the thing
status: open
```