### PR TITLE
fix: moved comments to the right location in the tree

### DIFF
--- a/pkg/au/storage.go
+++ b/pkg/au/storage.go
@@ -28,10 +28,10 @@ type DocProvider interface {
 }
 
 type WorkspaceMeta struct {
-	Id        string    `json:"id"`
-	Alias     string    `json:"alias"`
-	CreatedAt time.Time `json:"created_at"`
-	SizeBytes int64     `json:"size_bytes"`
+	Id        string    `yaml:"id"`
+	Alias     string    `yaml:"alias"`
+	CreatedAt time.Time `yaml:"created_at"`
+	SizeBytes int64     `yaml:"size_bytes"`
 }
 
 type CreateWorkspaceParams struct {


### PR DESCRIPTION
```
[0.06s 30-comments-are-global-and-not-stored-under-the-todo:s bmeier ~/projects/github.com/aurelian-one/au ⟫ au dev export-workspace
alias: Project A
created_at: "2024-02-09T08:58:16Z"
todos:
  01HP6HDV28HWMV31524D87BCV7:
    annotations: {}
    comments:
      01HP6HE6S1DNW4CTH2CQNYVSGD:
        content: SSd2ZSBzdGFydGVkIGxvb2tpbmcgYXQgdGhpcw==
        created_at: "2024-02-09T08:58:38Z"
        created_by: Ben Meier <ben@meierhost.com>
        media_type: text/markdown
    created_at: "2024-02-09T08:58:26Z"
    created_by: Ben Meier <ben@meierhost.com>
    description: '&automerge.Text{""}'
    status: open
    title: '&automerge.Text{"Do the thing"}'
```